### PR TITLE
Pass message info to RoOriginateErrorW

### DIFF
--- a/include/wil/result_originate.h
+++ b/include/wil/result_originate.h
@@ -60,19 +60,18 @@ namespace wil
 
                 if (shouldOriginate)
                 {
-                    auto message = wil::make_unique_string_nothrow<wil::unique_hstring>(failure.pszMessage);
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
                     wil::unique_hmodule errorModule;
                     if (GetModuleHandleExW(0, L"api-ms-win-core-winrt-error-l1-1-1.dll", &errorModule))
                     {
-                        auto pfn = reinterpret_cast<decltype(&::RoOriginateError)>(GetProcAddress(errorModule.get(), "RoOriginateError"));
+                        auto pfn = reinterpret_cast<decltype(&::RoOriginateErrorW)>(GetProcAddress(errorModule.get(), "RoOriginateErrorW"));
                         if (pfn != nullptr)
                         {
-                            pfn(failure.hr, message.get());
+                            pfn(failure.hr, 0, failure.pszMessage);
                         }
                     }
 #else // DESKTOP | SYSTEM
-                    ::RoOriginateError(failure.hr, message.get());
+                    ::RoOriginateErrorW(failure.hr, 0, failure.pszMessage);
 #endif // DESKTOP | SYSTEM
                 }
                 else if (restrictedErrorInformation)


### PR DESCRIPTION
Turns out that RoOriginateErrorW exists and is happy to take up to 512 characters of the error message!